### PR TITLE
Update Cilium version to v1.17.1 and CNI plugins image to v1.6.2-build20250306

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,7 +17,7 @@ jobs:
   updatecli:
     runs-on: ubuntu-latest
     # if you want to testupdatecli on another branch, you also need to modify updatecli/values.yaml
-    if: ${{github.ref == 'refs/heads/main-source' && github.repository == 'rancher/rke2-charts'}}
+    # if: ${{github.ref == 'refs/heads/main-source' && github.repository == 'rancher/rke2-charts'}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
@@ -200,7 +200,7 @@
 +portmapPlugin:
 +  image:
 +    repository: "rancher/hardened-cni-plugins"
-+    tag: "v1.6.2-build20250124"
++    tag: "v1.6.2-build20250306"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
 url: https://helm.cilium.io/cilium-1.17.1.tgz
-packageVersion: 00
+packageVersion: 01

--- a/updatecli/scripts/cilium-values.yaml.patch.template
+++ b/updatecli/scripts/cilium-values.yaml.patch.template
@@ -200,7 +200,7 @@
 +portmapPlugin:
 +  image:
 +    repository: "rancher/hardened-cni-plugins"
-+    tag: "v1.6.2-build20250124"
++    tag: "v1.6.2-build20250306"
 +
 +global:
 +  systemDefaultRegistry: ""

--- a/updatecli/scripts/create-issue.sh
+++ b/updatecli/scripts/create-issue.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TARGET_REPOSITORY="rancher/rke2"
+TARGET_REPOSITORY="thomasferrandiz/rke2"
 BODY="Url of the failed run: ${UPDATECLI_GITHUB_WORKFLOW_URL}"
 
 report-error() {

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+
+source $(dirname $0)/create-issue.sh
+
+ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_VERSION}" 
+trap report-error EXIT INT
+
+if [ -n "$COREDNS_VERSION" ]; then
+	coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
+	current_coredns_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $coredns_url)
+	if [ "$current_coredns_version" != "$COREDNS_VERSION" ]; then
+		echo "Updating Coredns chart to $COREDNS_VERSION"
+		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_VERSION}/coredns-${COREDNS_VERSION}.tgz\" |
+			.packageVersion = 00" packages/rke2-coredns/package.yaml
+		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-coredns' make prepare
+		find packages/rke2-coredns/charts -name '*.orig' -delete
+		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-coredns' make patch
+		make clean
+	fi
+fi

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -60,5 +60,4 @@ if [ -n "$COREDNS_CHART_VERSION" ]; then
 	GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make patch
 	# clean-up
 	make clean
-	fi
 fi

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -50,7 +50,7 @@ if [ -n "$COREDNS_CHART_VERSION" ]; then
 	fi
 
 	# 3 - update the package version accordingly
-	if [ "$CHART_UPDATED" = false && "$IMAGES_UPDATED" = true  ]; then
+	if [ "$CHART_UPDATED" = false ] && [ "$IMAGES_UPDATED" = true  ]; then
 		package_version=$(yq '.packageVersion' packages/rke2-coredns/package.yaml)
 		new_version=$(printf "%02d" $(($package_version + 1)))
 		yq -i ".packageVersion = $new_version" packages/rke2-coredns/package.yaml

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -6,6 +6,8 @@ source $(dirname $0)/create-issue.sh
 ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_VERSION}" 
 trap report-error EXIT INT
 
+HOMEDIR="/home/azureuser"
+
 if [ -n "$COREDNS_VERSION" ]; then
 	coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
 	current_coredns_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $coredns_url)
@@ -13,9 +15,9 @@ if [ -n "$COREDNS_VERSION" ]; then
 		echo "Updating Coredns chart to $COREDNS_VERSION"
 		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_VERSION}/coredns-${COREDNS_VERSION}.tgz\" |
 			.packageVersion = 00" packages/rke2-coredns/package.yaml
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-coredns' make prepare
+		GOCACHE='${HOMEDIR}/.cache/go-build' GOPATH='${HOMEDIR}/go' PACKAGE='rke2-coredns' make prepare
 		find packages/rke2-coredns/charts -name '*.orig' -delete
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-coredns' make patch
+		GOCACHE='${HOMEDIR}/.cache/go-build' GOPATH='${HOMEDIR}/go' PACKAGE='rke2-coredns' make patch
 		make clean
 	fi
 fi

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -6,8 +6,6 @@ source $(dirname $0)/create-issue.sh
 ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_VERSION}" 
 trap report-error EXIT INT
 
-HOMEDIR="/home/azureuser"
-
 if [ -n "$COREDNS_VERSION" ]; then
 	coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
 	current_coredns_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $coredns_url)
@@ -15,9 +13,9 @@ if [ -n "$COREDNS_VERSION" ]; then
 		echo "Updating Coredns chart to $COREDNS_VERSION"
 		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_VERSION}/coredns-${COREDNS_VERSION}.tgz\" |
 			.packageVersion = 00" packages/rke2-coredns/package.yaml
-		GOCACHE='${HOMEDIR}/.cache/go-build' GOPATH='${HOMEDIR}/go' PACKAGE='rke2-coredns' make prepare
+		GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make prepare
 		find packages/rke2-coredns/charts -name '*.orig' -delete
-		GOCACHE='${HOMEDIR}/.cache/go-build' GOPATH='${HOMEDIR}/go' PACKAGE='rke2-coredns' make patch
+		GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make patch
 		make clean
 	fi
 fi

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -3,15 +3,15 @@ set -eu
 
 source $(dirname $0)/create-issue.sh
 
-ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_VERSION}" 
+ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_CHART_VERSION}" 
 trap report-error EXIT INT
 
-if [ -n "$COREDNS_VERSION" ]; then
+if [ -n "$COREDNS_CHART_VERSION" ]; then
 	coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
 	current_coredns_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $coredns_url)
-	if [ "$current_coredns_version" != "$COREDNS_VERSION" ]; then
-		echo "Updating Coredns chart to $COREDNS_VERSION"
-		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_VERSION}/coredns-${COREDNS_VERSION}.tgz\" |
+	if [ "$current_coredns_version" != "$COREDNS_CHART_VERSION" ]; then
+		echo "Updating Coredns chart to $COREDNS_CHART_VERSION"
+		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_CHART_VERSION}/coredns-${COREDNS_CHART_VERSION}.tgz\" |
 			.packageVersion = 00" packages/rke2-coredns/package.yaml
 		GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make prepare
 		find packages/rke2-coredns/charts -name '*.orig' -delete

--- a/updatecli/scripts/update-coredns.sh
+++ b/updatecli/scripts/update-coredns.sh
@@ -6,16 +6,59 @@ source $(dirname $0)/create-issue.sh
 ISSUE_TITLE="Updatecli failed for coredns ${COREDNS_CHART_VERSION}" 
 trap report-error EXIT INT
 
+CHART_UPDATED=false
+IMAGES_UPDATED=false
+
 if [ -n "$COREDNS_CHART_VERSION" ]; then
-	coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
-	current_coredns_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $coredns_url)
-	if [ "$current_coredns_version" != "$COREDNS_CHART_VERSION" ]; then
+	# 1 - check if there is a new upstream chart
+	current_coredns_url=$(yq '.url' packages/rke2-coredns/package.yaml)
+	current_coredns_chart_version=$(awk -F'/coredns-|.tgz' '{print $2}' <<< $current_coredns_url)
+	if [ "$current_coredns_chart_version" != "$COREDNS_CHART_VERSION" ]; then
 		echo "Updating Coredns chart to $COREDNS_CHART_VERSION"
+		# if there is a new chart, reset the package version to 00 even if the images are also updated
 		yq -i ".url = \"https://github.com/coredns/helm/releases/download/coredns-${COREDNS_CHART_VERSION}/coredns-${COREDNS_CHART_VERSION}.tgz\" |
 			.packageVersion = 00" packages/rke2-coredns/package.yaml
-		GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make prepare
-		find packages/rke2-coredns/charts -name '*.orig' -delete
-		GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make patch
-		make clean
+		CHART_UPDATED=true
+	fi
+	GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make prepare
+
+	# 2 - check if the images have been updated
+	if [ -n "$COREDNS_VERSION" ]; then
+		current_coredns_version=$(yq '.image.tag' packages/rke2-coredns/charts/values.yaml)
+		if [ "$current_coredns_version" != "$COREDNS_VERSION" ]; then
+			echo "Updating coredns image to $COREDNS_VERSION"
+			yq -i ".image.tag = \"$COREDNS_VERSION\"" packages/rke2-coredns/charts/values.yaml
+			IMAGES_UPDATED=true
+		fi
+	fi
+	if [ -n "$AUTOSCALER_VERSION" ]; then
+		current_autoscaler_version=$(yq '.autoscaler.image.tag' packages/rke2-coredns/charts/values.yaml)
+		if [ "$current_autoscaler_version" != "$AUTOSCALER_VERSION" ]; then
+			echo "Updating autoscaler image to $AUTOSCALER_VERSION"
+			yq -i ".autoscaler.image.tag = \"$AUTOSCALER_VERSION\"" packages/rke2-coredns/charts/values.yaml
+			IMAGES_UPDATED=true
+		fi
+	fi
+	if [ -n "$NODECACHE_VERSION" ]; then
+		current_nodecache_version=$(yq '.nodelocal.image.tag' packages/rke2-coredns/charts/values.yaml)
+		if [ "$current_nodecache_version" != "$NODECACHE_VERSION" ]; then
+			echo "Updating nodecache image to $NODECACHE_VERSION"
+			yq -i ".nodelocal.image.tag = \"$NODECACHE_VERSION\" |
+				  .nodelocal.initimage.tag = \"$NODECACHE_VERSION\"" packages/rke2-coredns/charts/values.yaml
+			IMAGES_UPDATED=true
+		fi
+	fi
+
+	# 3 - update the package version accordingly
+	if [ "$CHART_UPDATED" = false && "$IMAGES_UPDATED" = true  ]; then
+		package_version=$(yq '.packageVersion' packages/rke2-coredns/package.yaml)
+		new_version=$(printf "%02d" $(($package_version + 1)))
+		yq -i ".packageVersion = $new_version" packages/rke2-coredns/package.yaml
+	fi
+	# prepare patch
+	find packages/rke2-coredns/charts -name '*.orig' -delete
+	GOCACHE='/home/azureuser/.cache/go-build' GOPATH='/home/azureuser/go' PACKAGE='rke2-coredns' make patch
+	# clean-up
+	make clean
 	fi
 fi

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -17,6 +17,8 @@ sources:
         kind: regex
         # pattern accepts any semver constraint without leading 'v'
         pattern: "[0-9]+.[0-9]+.[0-9]"
+    transformers:
+      - trimPrefix: "coredns-"
   coredns:
     name: Get coredns image version
     kind: githubrelease
@@ -33,8 +35,6 @@ sources:
         kind: regex
         # pattern accepts any semver constraint
         pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
-    transformers:
-      - trimPrefix: "coredns-"
   autoscaler:
     name: Get autoscaler image version
     kind: githubrelease

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -14,7 +14,9 @@ sources:
         draft: false
         prerelease: false
       versionfilter:
-        kind: semver
+        kind: regex
+        # pattern accepts any semver constraint without leading 'v'
+        pattern: "[0-9]+.[0-9]+.[0-9]"
   coredns:
     name: Get coredns image version
     kind: githubrelease
@@ -61,8 +63,8 @@ sources:
         prerelease: false
       versionfilter:
         kind: regex
-        # pattern accepts any semver constraint
-        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+        # pattern accepts any semver constraint  without leading 'v'
+        pattern: "[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
 
 targets:
   coredns:

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -1,0 +1,110 @@
+---
+name: "Update coredns version" 
+
+sources:
+  coredns_chart:
+    name: Get coredns chart version
+    kind: githubrelease
+    spec:
+      owner: coredns
+      repository: helm
+      token: '{{ requiredEnv .github.token }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: semver
+  coredns:
+    name: Get coredns image version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-coredns
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+  autoscaler:
+    name: Get autoscaler image version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cluster-proportional-autoscaler
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+  nodecache:
+    name: Get nodecache image version
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-dns-nodecache
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # pattern accepts any semver constraint
+        pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+
+targets:
+  coredns:
+    name: "Bump to latest coredns chart and images version"
+    kind: shell
+    scmid: default
+    sourceid: coredns_chart
+    spec:
+      command: 'updatecli/scripts/update-coredns.sh'
+      environments:
+        - name: COREDNS_CHART_VERSION
+          value: '{{ source "coredns_chart" }}'
+        - name: COREDNS_VERSION
+          value: '{{ source "coredns" }}'
+        - name: AUTOSCALER_VERSION
+          value: '{{ source "autoscaler" }}'
+        - name: NODECACHE_VERSION
+          value: '{{ source "nodecache" }}'
+        - name: PATH
+        - name: UPDATECLI_GITHUB_WORKFLOW_URL
+        - name: GH_TOKEN
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+  default:
+    title: 'Update Coredns chart version to {{ source "coredns" }}'
+    kind: github/pullrequest
+    spec:
+      automerge: false
+      labels:
+        - chore
+        - skip-changelog
+        - status/auto-created 
+    scmid: default

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -18,7 +18,7 @@ sources:
         # pattern accepts any semver constraint without leading 'v'
         pattern: "[0-9]+.[0-9]+.[0-9]"
     transformers:
-      - trimPrefix: "coredns-"
+      - trimprefix: "coredns-"
   coredns:
     name: Get coredns image version
     kind: githubrelease

--- a/updatecli/updatecli.d/updatecoredns.yaml
+++ b/updatecli/updatecli.d/updatecoredns.yaml
@@ -33,6 +33,8 @@ sources:
         kind: regex
         # pattern accepts any semver constraint
         pattern: "v[0-9]+.[0-9]+.[0-9]+-build[0-9]+"
+    transformers:
+      - trimPrefix: "coredns-"
   autoscaler:
     name: Get autoscaler image version
     kind: githubrelease

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -4,5 +4,5 @@ github:
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
   repository: "rke2-charts"
-  branch: "main-source"
-  owner: "rancher"
+  branch: "coredns-updatecli"
+  owner: "thomasferrandiz"


### PR DESCRIPTION



<Actions>
    <action id="9f2a1a904b57d2e000d70ce8846ca1c460e9b72a7b72f51e30bc766139ae0d19">
        <h3>Update Cilium version</h3>
        <details id="04343367bedc8bc45741f90150e743990773277508f540d889fd5d7fba9672e1">
            <summary>Bump to latest cilium version on the chart</summary>
            <p>ran shell command &#34;updatecli/scripts/update-cilium.sh v1.17.1&#34;</p>
            <details>
                <summary>v1.17.1</summary>
                <pre>&#xA;Release published on the 2025-02-18 16:55:27 +0000 UTC at the url https://github.com/cilium/cilium/releases/tag/v1.17.1&#xA;&#xA;Summary of Changes&#xD;&#xA;------------------&#xD;&#xA;&#xD;&#xA;**Minor Changes:**&#xD;&#xA;* [v1.17] agent: Deprecate lb-only mode (cilium/cilium#37391, @brb)&#xD;&#xA;* helm: Update CiliumNodeConfig version (Backport PR cilium/cilium#37440, Upstream PR cilium/cilium#37403, @sayboras)&#xD;&#xA;&#xD;&#xA;**Bugfixes:**&#xD;&#xA;* ces: Fix bug where stale endpoint information was injected into IPCache (Backport PR cilium/cilium#37416, Upstream PR cilium/cilium#37347, @gandro)&#xD;&#xA;* socket-lb: Fix null pointer dereference in socketlb/cgroup.go (Backport PR cilium/cilium#37440, Upstream PR cilium/cilium#37426, @alvaroaleman)&#xD;&#xA;&#xD;&#xA;**CI Changes:**&#xD;&#xA;* test: Move the dind image to Quay to avoid rate-limiting (Backport PR cilium/cilium#37440, Upstream PR cilium/cilium#37388, @pchaigno)&#xD;&#xA;&#xD;&#xA;**Misc Changes:**&#xD;&#xA;* chore(deps): update all github action dependencies (v1.17) (cilium/cilium#37502, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all-dependencies (v1.17) (cilium/cilium#37342, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update dependency cilium/little-vm-helper to v0.0.23 (v1.17) (cilium/cilium#37501, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update go to v1.23.6 (v1.17) (cilium/cilium#37446, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update stable lvh-images (v1.17) (patch) (cilium/cilium#37409, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update stable lvh-images (v1.17) (patch) (cilium/cilium#37496, @cilium-renovate[bot])&#xD;&#xA;&#xD;&#xA;**Other Changes:**&#xD;&#xA;* install: Update image digests for v1.17.0 (cilium/cilium#37432, @cilium-release-bot[bot])&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## Docker Manifests&#xD;&#xA;&#xD;&#xA;### cilium&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/cilium:v1.17.1@sha256:8969bfd9c87cbea91e40665f8ebe327268c99d844ca26d7d12165de07f702866`&#xD;&#xA;`quay.io/cilium/cilium:stable@sha256:8969bfd9c87cbea91e40665f8ebe327268c99d844ca26d7d12165de07f702866`&#xD;&#xA;&#xD;&#xA;### clustermesh-apiserver&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/clustermesh-apiserver:v1.17.1@sha256:1de22f46bfdd638de72c2224d5223ddc3bbeacda1803cb75799beca3d4bf7a4c`&#xD;&#xA;`quay.io/cilium/clustermesh-apiserver:stable@sha256:1de22f46bfdd638de72c2224d5223ddc3bbeacda1803cb75799beca3d4bf7a4c`&#xD;&#xA;&#xD;&#xA;### docker-plugin&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/docker-plugin:v1.17.1@sha256:d4d838be1d8c20eaf1810f1be1ccc963e8229653357ec6cf8e8c1a53f3f03a71`&#xD;&#xA;`quay.io/cilium/docker-plugin:stable@sha256:d4d838be1d8c20eaf1810f1be1ccc963e8229653357ec6cf8e8c1a53f3f03a71`&#xD;&#xA;&#xD;&#xA;### hubble-relay&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/hubble-relay:v1.17.1@sha256:397e8fbb188157f744390a7b272a1dec31234e605bcbe22d8919a166d202a3dc`&#xD;&#xA;`quay.io/cilium/hubble-relay:stable@sha256:397e8fbb188157f744390a7b272a1dec31234e605bcbe22d8919a166d202a3dc`&#xD;&#xA;&#xD;&#xA;### operator-alibabacloud&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-alibabacloud:v1.17.1@sha256:034b479fba340f9d98510e509c7ce1c36e8889a109d5f1c2240fcb0942bc772c`&#xD;&#xA;`quay.io/cilium/operator-alibabacloud:stable@sha256:034b479fba340f9d98510e509c7ce1c36e8889a109d5f1c2240fcb0942bc772c`&#xD;&#xA;&#xD;&#xA;### operator-aws&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-aws:v1.17.1@sha256:da74748057c836471bfdc0e65bb29ba0edb82916ec4b99f6a4f002b2fcc849d6`&#xD;&#xA;`quay.io/cilium/operator-aws:stable@sha256:da74748057c836471bfdc0e65bb29ba0edb82916ec4b99f6a4f002b2fcc849d6`&#xD;&#xA;&#xD;&#xA;### operator-azure&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-azure:v1.17.1@sha256:b9e3e3994f5fcf1832e1f344f3b3b544832851b1990f124b2c2c68e3ffe04a9b`&#xD;&#xA;`quay.io/cilium/operator-azure:stable@sha256:b9e3e3994f5fcf1832e1f344f3b3b544832851b1990f124b2c2c68e3ffe04a9b`&#xD;&#xA;&#xD;&#xA;### operator-generic&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-generic:v1.17.1@sha256:628becaeb3e4742a1c36c4897721092375891b58bae2bfcae48bbf4420aaee97`&#xD;&#xA;`quay.io/cilium/operator-generic:stable@sha256:628becaeb3e4742a1c36c4897721092375891b58bae2bfcae48bbf4420aaee97`&#xD;&#xA;&#xD;&#xA;### operator&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator:v1.17.1@sha256:5c5f4408112365ae10ebcbab2621c273cebc671fe63b0f19cc1376326f140f89`&#xD;&#xA;`quay.io/cilium/operator:stable@sha256:5c5f4408112365ae10ebcbab2621c273cebc671fe63b0f19cc1376326f140f89`&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

